### PR TITLE
Embeds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ idf_component_register(
          src/discord/channel.c
          src/discord/role.c
          src/discord/attachment.c
+         src/discord/embed.c
          src/discord/voice_state.c
          src/discord.c
          src/discord_ota.c

--- a/include/discord.h
+++ b/include/discord.h
@@ -67,6 +67,39 @@ extern "C" {
 #define DISCORD_PERMISSION_MANAGE_WEBHOOKS        0x20000000ULL  /*!< Allows management and editing of webhooks */
 #define DISCORD_PERMISSION_MANAGE_EMOJIS          0x40000000ULL  /*!< Allows management and editing of emojis */
 
+// colors (taken from https://bit.ly/3QMMXQr)
+
+#define DISCORD_COLOR_DEFAULT              (0)
+#define DISCORD_COLOR_AQUA                 (1752220)
+#define DISCORD_COLOR_DARK_AQUA            (1146986)
+#define DISCORD_COLOR_GREEN                (3066993)
+#define DISCORD_COLOR_DARK_GREEN           (2067276)
+#define DISCORD_COLOR_BLUE                 (3447003)
+#define DISCORD_COLOR_DARK_BLUE            (2123412)
+#define DISCORD_COLOR_PURPLE               (10181046)
+#define DISCORD_COLOR_DARK_PURPLE          (7419530)
+#define DISCORD_COLOR_LUMINOUS_VIVID_PINK  (15277667)
+#define DISCORD_COLOR_DARK_VIVID_PINK      (11342935)
+#define DISCORD_COLOR_GOLD                 (15844367)
+#define DISCORD_COLOR_DARK_GOLD            (12745742)
+#define DISCORD_COLOR_ORANGE               (15105570)
+#define DISCORD_COLOR_DARK_ORANGE          (11027200)
+#define DISCORD_COLOR_RED                  (15158332)
+#define DISCORD_COLOR_DARK_RED             (10038562)
+#define DISCORD_COLOR_GREY                 (9807270)
+#define DISCORD_COLOR_DARK_GREY            (9936031)
+#define DISCORD_COLOR_DARKER_GREY          (8359053)
+#define DISCORD_COLOR_LIGHT_GREY           (12370112)
+#define DISCORD_COLOR_NAVY                 (3426654)
+#define DISCORD_COLOR_DARK_NAVY            (2899536)
+#define DISCORD_COLOR_YELLOW               (16776960)
+#define DISCORD_COLOR_WHITE                (16777215)
+#define DISCORD_COLOR_BLURPLE              (5793266)
+#define DISCORD_COLOR_GREYPLE              (10070709)
+#define DISCORD_COLOR_DARK_BUT_NOT_BLACK   (2895667)
+#define DISCORD_COLOR_NOT_QUITE_BLACK      (2303786)
+#define DISCORD_COLOR_FUSCHIA              (15418782)
+
 typedef struct discord* discord_handle_t;
 
 typedef struct {

--- a/include/discord/attachment.h
+++ b/include/discord/attachment.h
@@ -13,7 +13,7 @@ typedef struct {
     char* content_type;
     size_t size;
     char* url;
-    uint8_t* _data;
+    char* _data;
     bool _data_should_be_freed; /*<! Set to true if _data should be freed by discord_attachment_free function */
 } discord_attachment_t;
 

--- a/include/discord/embed.h
+++ b/include/discord/embed.h
@@ -8,16 +8,22 @@ extern "C" {
 #include "discord.h"
 
 typedef struct {
-    char* text;                     /*!< Footer text */
-    char* icon_url;                 /*!< Url of footer icon (only supports http(s) and attachments) */
+    char* text;                       /*!< Footer text */
+    char* icon_url;                   /*!< Url of footer icon (only supports http(s) and attachments) */
 } discord_embed_footer_t;
 
 typedef struct {
-    char* title;                    /*!< Title of embed. Limit: 256 */
-    char* description;              /*!< Description of embed. Limit: 4096 */
-    char* url;                      /*!< Url of embed */
-    int color;                      /*!< Color code of the embed. DISCORD_COLOR_* predefines can be used */
-    discord_embed_footer_t* footer; /*!< Footer information */
+    char* url;                        /*!< Source url (only supports http(s) and attachments) */
+} discord_embed_image_t;
+
+typedef struct {
+    char* title;                      /*!< Title of embed. Limit: 256 */
+    char* description;                /*!< Description of embed. Limit: 4096 */
+    char* url;                        /*!< Url of embed */
+    int color;                        /*!< Color code of the embed. DISCORD_COLOR_* predefines can be used */
+    discord_embed_footer_t* footer;   /*!< Footer information */
+    discord_embed_image_t* thumbnail; /*!< Thumbnail information */
+    discord_embed_image_t* image;     /*!< Image information */
 } discord_embed_t;
 
 void discord_embed_free(discord_embed_t* embed);

--- a/include/discord/embed.h
+++ b/include/discord/embed.h
@@ -8,10 +8,16 @@ extern "C" {
 #include "discord.h"
 
 typedef struct {
+    char* text;      /*!< Footer text */
+    char* icon_url;  /*!< Url of footer icon (only supports http(s) and attachments) */
+} discord_embed_footer_t;
+
+typedef struct {
     char* title;
     char* description;
     char* url;
     int color;
+    discord_embed_footer_t* footer;
 } discord_embed_t;
 
 void discord_embed_free(discord_embed_t* embed);

--- a/include/discord/embed.h
+++ b/include/discord/embed.h
@@ -10,6 +10,7 @@ extern "C" {
 typedef struct {
     char* title;
     char* description;
+    char* url;
 } discord_embed_t;
 
 void discord_embed_free(discord_embed_t* embed);

--- a/include/discord/embed.h
+++ b/include/discord/embed.h
@@ -11,6 +11,7 @@ typedef struct {
     char* title;
     char* description;
     char* url;
+    int color;
 } discord_embed_t;
 
 void discord_embed_free(discord_embed_t* embed);

--- a/include/discord/embed.h
+++ b/include/discord/embed.h
@@ -1,0 +1,21 @@
+#ifndef _DISCORD_EMBED_H_
+#define _DISCORD_EMBED_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "discord.h"
+
+typedef struct {
+    char* title;
+    char* description;
+} discord_embed_t;
+
+void discord_embed_free(discord_embed_t* embed);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/discord/embed.h
+++ b/include/discord/embed.h
@@ -8,7 +8,7 @@ extern "C" {
 #include "discord.h"
 
 typedef struct {
-    char* text;                       /*!< Footer text */
+    char* text;                       /*!< Footer text. Limit: 2048 */
     char* icon_url;                   /*!< Url of footer icon (only supports http(s) and attachments) */
 } discord_embed_footer_t;
 
@@ -17,10 +17,16 @@ typedef struct {
 } discord_embed_image_t;
 
 typedef struct {
-    char* name;                       /*!< Name of author */
+    char* name;                       /*!< Name of author. Limit: 256 */
     char* url;                        /*!< Url of author */
     char* icon_url;                   /*!< Url of author icon (only supports http(s) and attachments) */
 } discord_embed_author_t;
+
+typedef struct {
+    char* name;                       /*!< Name of the field. Limit: 256 */
+    char* value;                      /*!< Value of the field. Limit: 1024 */
+    bool is_inline;                   /*!< Whether or not this field should display inline */
+} discord_embed_field_t;
 
 typedef struct {
     char* title;                      /*!< Title of embed. Limit: 256 */
@@ -31,8 +37,11 @@ typedef struct {
     discord_embed_image_t* thumbnail; /*!< Thumbnail information */
     discord_embed_image_t* image;     /*!< Image information */
     discord_embed_author_t* author;   /*!< Author information */
+    discord_embed_field_t** fields;   /*!< Fields information. Maximum fields: 25 */
+    uint8_t _fields_len;
 } discord_embed_t;
 
+esp_err_t discord_embed_add_field(discord_embed_t* embed, discord_embed_field_t* field);
 void discord_embed_free(discord_embed_t* embed);
 
 #ifdef __cplusplus

--- a/include/discord/embed.h
+++ b/include/discord/embed.h
@@ -17,6 +17,12 @@ typedef struct {
 } discord_embed_image_t;
 
 typedef struct {
+    char* name;                       /*!< Name of author */
+    char* url;                        /*!< Url of author */
+    char* icon_url;                   /*!< Url of author icon (only supports http(s) and attachments) */
+} discord_embed_author_t;
+
+typedef struct {
     char* title;                      /*!< Title of embed. Limit: 256 */
     char* description;                /*!< Description of embed. Limit: 4096 */
     char* url;                        /*!< Url of embed */
@@ -24,6 +30,7 @@ typedef struct {
     discord_embed_footer_t* footer;   /*!< Footer information */
     discord_embed_image_t* thumbnail; /*!< Thumbnail information */
     discord_embed_image_t* image;     /*!< Image information */
+    discord_embed_author_t* author;   /*!< Author information */
 } discord_embed_t;
 
 void discord_embed_free(discord_embed_t* embed);

--- a/include/discord/embed.h
+++ b/include/discord/embed.h
@@ -8,16 +8,16 @@ extern "C" {
 #include "discord.h"
 
 typedef struct {
-    char* text;      /*!< Footer text */
-    char* icon_url;  /*!< Url of footer icon (only supports http(s) and attachments) */
+    char* text;                     /*!< Footer text */
+    char* icon_url;                 /*!< Url of footer icon (only supports http(s) and attachments) */
 } discord_embed_footer_t;
 
 typedef struct {
-    char* title;
-    char* description;
-    char* url;
-    int color;
-    discord_embed_footer_t* footer;
+    char* title;                    /*!< Title of embed. Limit: 256 */
+    char* description;              /*!< Description of embed. Limit: 4096 */
+    char* url;                      /*!< Url of embed */
+    int color;                      /*!< Color code of the embed. DISCORD_COLOR_* predefines can be used */
+    discord_embed_footer_t* footer; /*!< Footer information */
 } discord_embed_t;
 
 void discord_embed_free(discord_embed_t* embed);

--- a/include/discord/message.h
+++ b/include/discord/message.h
@@ -6,6 +6,7 @@
 #include "discord/member.h"
 #include "discord/message_reaction.h"
 #include "discord/attachment.h"
+#include "discord/embed.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,6 +50,8 @@ typedef struct {
     discord_member_t* member;
     discord_attachment_t** attachments;
     uint8_t _attachments_len;
+    discord_embed_t** embeds;
+    uint8_t _embeds_len;
 } discord_message_t;
 
 typedef enum {
@@ -86,6 +89,7 @@ esp_err_t discord_message_react(discord_handle_t client, discord_message_t* mess
 esp_err_t discord_message_download_attachment(discord_handle_t client, discord_message_t* message, uint8_t attachment_index, discord_download_handler_t download_handler, void* arg);
 esp_err_t discord_message_word_parse(const char* word, discord_message_word_t** out_word);
 esp_err_t discord_message_add_attachment(discord_message_t* message, discord_attachment_t* attachment);
+esp_err_t discord_message_add_embed(discord_message_t* message, discord_embed_t* embed);
 void discord_message_free(discord_message_t* message);
 
 #ifdef __cplusplus

--- a/include/discord/private/_json.h
+++ b/include/discord/private/_json.h
@@ -75,6 +75,8 @@ cJSON* discord_member_to_cjson(discord_member_t* member);
 discord_attachment_t* discord_attachment_from_cjson(cJSON* root);
 cJSON* discord_attachment_to_cjson(discord_attachment_t* attachment);
 
+cJSON* discord_embed_to_cjson(discord_embed_t* embed);
+
 discord_guild_t* discord_guild_from_cjson(cJSON* root);
 cJSON* discord_guild_to_cjson(discord_guild_t* guild);
 

--- a/src/discord/embed.c
+++ b/src/discord/embed.c
@@ -65,13 +65,11 @@ void discord_embed_free(discord_embed_t* embed)
     discord_embed_image_free(embed->image);
     discord_embed_author_free(embed->author);
 
-    if(embed->_fields_len > 0 && embed->fields) {
-        for(uint8_t i = 0; i < embed->_fields_len; i++) {
-            discord_embed_field_free(embed->fields[i]);
-        }
-
-        embed->_fields_len = 0;
+    for(uint8_t i = 0; i < embed->_fields_len; i++) {
+        discord_embed_field_free(embed->fields[i]);
     }
+
+    embed->_fields_len = 0;
 
     free(embed);
 }

--- a/src/discord/embed.c
+++ b/src/discord/embed.c
@@ -1,0 +1,10 @@
+#include "discord/embed.h"
+
+void discord_embed_free(discord_embed_t* embed) {
+    if(!embed)
+        return;
+
+    free(embed->title);
+    free(embed->description);
+    free(embed);
+}

--- a/src/discord/embed.c
+++ b/src/discord/embed.c
@@ -1,11 +1,23 @@
 #include "discord/embed.h"
 
-void discord_embed_free(discord_embed_t* embed) {
+static void discord_embed_footer_free(discord_embed_footer_t* footer)
+{
+    if(!footer)
+        return;
+    
+    free(footer->text);
+    free(footer->icon_url);
+    free(footer);
+}
+
+void discord_embed_free(discord_embed_t* embed)
+{
     if(!embed)
         return;
 
     free(embed->title);
     free(embed->description);
     free(embed->url);
+    discord_embed_footer_free(embed->footer);
     free(embed);
 }

--- a/src/discord/embed.c
+++ b/src/discord/embed.c
@@ -30,6 +30,28 @@ static void discord_embed_author_free(discord_embed_author_t* author)
     free(author);
 }
 
+static void discord_embed_field_free(discord_embed_field_t* field)
+{
+    if(!field)
+        return;
+    
+    free(field->name);
+    free(field->value);
+    free(field);
+}
+
+esp_err_t discord_embed_add_field(discord_embed_t* embed, discord_embed_field_t* field)
+{
+    if(! embed || ! field) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    embed->fields = realloc(embed->fields, ++embed->_fields_len * sizeof(discord_embed_field_t*));
+    embed->fields[embed->_fields_len - 1] = field;
+
+    return ESP_OK;
+}
+
 void discord_embed_free(discord_embed_t* embed)
 {
     if(!embed)
@@ -42,5 +64,14 @@ void discord_embed_free(discord_embed_t* embed)
     discord_embed_image_free(embed->thumbnail);
     discord_embed_image_free(embed->image);
     discord_embed_author_free(embed->author);
+
+    if(embed->_fields_len > 0 && embed->fields) {
+        for(uint8_t i = 0; i < embed->_fields_len; i++) {
+            discord_embed_field_free(embed->fields[i]);
+        }
+
+        embed->_fields_len = 0;
+    }
+
     free(embed);
 }

--- a/src/discord/embed.c
+++ b/src/discord/embed.c
@@ -19,6 +19,17 @@ static void discord_embed_footer_free(discord_embed_footer_t* footer)
     free(footer);
 }
 
+static void discord_embed_author_free(discord_embed_author_t* author)
+{
+    if(!author)
+        return;
+    
+    free(author->name);
+    free(author->url);
+    free(author->icon_url);
+    free(author);
+}
+
 void discord_embed_free(discord_embed_t* embed)
 {
     if(!embed)
@@ -30,5 +41,6 @@ void discord_embed_free(discord_embed_t* embed)
     discord_embed_footer_free(embed->footer);
     discord_embed_image_free(embed->thumbnail);
     discord_embed_image_free(embed->image);
+    discord_embed_author_free(embed->author);
     free(embed);
 }

--- a/src/discord/embed.c
+++ b/src/discord/embed.c
@@ -6,5 +6,6 @@ void discord_embed_free(discord_embed_t* embed) {
 
     free(embed->title);
     free(embed->description);
+    free(embed->url);
     free(embed);
 }

--- a/src/discord/embed.c
+++ b/src/discord/embed.c
@@ -1,5 +1,14 @@
 #include "discord/embed.h"
 
+static void discord_embed_image_free(discord_embed_image_t* image)
+{
+    if(!image)
+        return;
+    
+    free(image->url);
+    free(image);
+}
+
 static void discord_embed_footer_free(discord_embed_footer_t* footer)
 {
     if(!footer)
@@ -19,5 +28,7 @@ void discord_embed_free(discord_embed_t* embed)
     free(embed->description);
     free(embed->url);
     discord_embed_footer_free(embed->footer);
+    discord_embed_image_free(embed->thumbnail);
+    discord_embed_image_free(embed->image);
     free(embed);
 }

--- a/src/discord/message.c
+++ b/src/discord/message.c
@@ -13,7 +13,7 @@ static discord_api_multipart_t* discord_message_create_multipart_from_attachment
         .name                  = estr_cat("files[", attachment->id, "]"),
         .mime_type             = strdup(attachment->content_type),
         .filename              = strdup(attachment->filename),
-        .data                  = (char*) attachment->_data,
+        .data                  = attachment->_data,
         .len                   = attachment->size,
         .data_should_be_freed  = attachment->_data_should_be_freed,
     );

--- a/src/discord/message.c
+++ b/src/discord/message.c
@@ -157,6 +157,18 @@ esp_err_t discord_message_add_attachment(discord_message_t* message, discord_att
     return ESP_OK;
 }
 
+esp_err_t discord_message_add_embed(discord_message_t* message, discord_embed_t* embed)
+{
+    if(! message || ! embed) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    message->embeds = realloc(message->embeds, ++message->_embeds_len * sizeof(discord_embed_t*));
+    message->embeds[message->_embeds_len - 1] = embed;
+
+    return ESP_OK;
+}
+
 void discord_message_free(discord_message_t* message) {
     if(!message)
         return;
@@ -168,5 +180,6 @@ void discord_message_free(discord_message_t* message) {
     free(message->guild_id);
     discord_member_free(message->member);
     cu_list_freex(message->attachments, message->_attachments_len, discord_attachment_free);
+    cu_list_freex(message->embeds, message->_embeds_len, discord_embed_free);
     free(message);
 }

--- a/src/discord/private/_json.c
+++ b/src/discord/private/_json.c
@@ -309,6 +309,7 @@ cJSON* discord_embed_to_cjson(discord_embed_t* embed)
     if(embed->title) cJSON_AddItemToObject(root, "title", cJSON_CreateStringReference(embed->title));
     if(embed->description) cJSON_AddItemToObject(root, "description", cJSON_CreateStringReference(embed->description));
     if(embed->url) cJSON_AddItemToObject(root, "url", cJSON_CreateStringReference(embed->url));
+    cJSON_AddNumberToObject(root, "color", embed->color);
 
     return root;
 }

--- a/src/discord/private/_json.c
+++ b/src/discord/private/_json.c
@@ -324,6 +324,20 @@ static cJSON* discord_embed_image_to_cjson(discord_embed_image_t* image)
     return root;
 }
 
+static cJSON* discord_embed_author_to_cjson(discord_embed_author_t* author)
+{
+    if(!author)
+        return NULL;
+    
+    cJSON* root = cJSON_CreateObject();
+
+    if(author->name) cJSON_AddItemToObject(root, "name", cJSON_CreateStringReference(author->name));
+    if(author->url) cJSON_AddItemToObject(root, "url", cJSON_CreateStringReference(author->url));
+    if(author->icon_url) cJSON_AddItemToObject(root, "icon_url", cJSON_CreateStringReference(author->icon_url));
+
+    return root;
+}
+
 cJSON* discord_embed_to_cjson(discord_embed_t* embed)
 {
     if(!embed)
@@ -338,6 +352,7 @@ cJSON* discord_embed_to_cjson(discord_embed_t* embed)
     if(embed->footer) cJSON_AddItemToObject(root, "footer", discord_embed_footer_to_cjson(embed->footer));
     if(embed->image) cJSON_AddItemToObject(root, "image", discord_embed_image_to_cjson(embed->image));
     if(embed->thumbnail) cJSON_AddItemToObject(root, "thumbnail", discord_embed_image_to_cjson(embed->thumbnail));
+    if(embed->author) cJSON_AddItemToObject(root, "author", discord_embed_author_to_cjson(embed->author));
 
     return root;
 }

--- a/src/discord/private/_json.c
+++ b/src/discord/private/_json.c
@@ -299,6 +299,19 @@ cJSON* discord_attachment_to_cjson(discord_attachment_t* attachment) {
     return root;
 }
 
+static cJSON* discord_embed_footer_to_cjson(discord_embed_footer_t* footer)
+{
+    if(!footer)
+        return NULL;
+    
+    cJSON* root = cJSON_CreateObject();
+
+    if(footer->text) cJSON_AddItemToObject(root, "text", cJSON_CreateStringReference(footer->text));
+    if(footer->icon_url) cJSON_AddItemToObject(root, "icon_url", cJSON_CreateStringReference(footer->icon_url));
+
+    return root;
+}
+
 cJSON* discord_embed_to_cjson(discord_embed_t* embed)
 {
     if(!embed)
@@ -310,6 +323,7 @@ cJSON* discord_embed_to_cjson(discord_embed_t* embed)
     if(embed->description) cJSON_AddItemToObject(root, "description", cJSON_CreateStringReference(embed->description));
     if(embed->url) cJSON_AddItemToObject(root, "url", cJSON_CreateStringReference(embed->url));
     cJSON_AddNumberToObject(root, "color", embed->color);
+    if(embed->footer) cJSON_AddItemToObject(root, "footer", discord_embed_footer_to_cjson(embed->footer));
 
     return root;
 }

--- a/src/discord/private/_json.c
+++ b/src/discord/private/_json.c
@@ -299,6 +299,19 @@ cJSON* discord_attachment_to_cjson(discord_attachment_t* attachment) {
     return root;
 }
 
+cJSON* discord_embed_to_cjson(discord_embed_t* embed)
+{
+    if(!embed)
+        return NULL;
+    
+    cJSON* root = cJSON_CreateObject();
+
+    if(embed->title) cJSON_AddItemToObject(root, "title", cJSON_CreateStringReference(embed->title));
+    if(embed->description) cJSON_AddItemToObject(root, "description", cJSON_CreateStringReference(embed->description));
+
+    return root;
+}
+
 discord_guild_t* discord_guild_from_cjson(cJSON* root) {
     if(!root)
         return NULL;
@@ -488,6 +501,16 @@ cJSON* discord_message_to_cjson(discord_message_t* msg) {
         }
 
         cJSON_AddItemToObject(root, "attachments", attachments);
+    }
+
+    if(msg->_embeds_len > 0 && msg->embeds) {
+        cJSON* embeds = cJSON_CreateArray();
+
+        for(uint8_t i = 0; i < msg->_embeds_len; i++) {
+            cJSON_AddItemToArray(embeds, discord_embed_to_cjson(msg->embeds[i]));
+        }
+
+        cJSON_AddItemToObject(root, "embeds", embeds);
     }
 
     // todo: memchecks

--- a/src/discord/private/_json.c
+++ b/src/discord/private/_json.c
@@ -308,6 +308,7 @@ cJSON* discord_embed_to_cjson(discord_embed_t* embed)
 
     if(embed->title) cJSON_AddItemToObject(root, "title", cJSON_CreateStringReference(embed->title));
     if(embed->description) cJSON_AddItemToObject(root, "description", cJSON_CreateStringReference(embed->description));
+    if(embed->url) cJSON_AddItemToObject(root, "url", cJSON_CreateStringReference(embed->url));
 
     return root;
 }

--- a/src/discord/private/_json.c
+++ b/src/discord/private/_json.c
@@ -312,6 +312,18 @@ static cJSON* discord_embed_footer_to_cjson(discord_embed_footer_t* footer)
     return root;
 }
 
+static cJSON* discord_embed_image_to_cjson(discord_embed_image_t* image)
+{
+    if(!image)
+        return NULL;
+    
+    cJSON* root = cJSON_CreateObject();
+
+    if(image->url) cJSON_AddItemToObject(root, "url", cJSON_CreateStringReference(image->url));
+
+    return root;
+}
+
 cJSON* discord_embed_to_cjson(discord_embed_t* embed)
 {
     if(!embed)
@@ -324,6 +336,8 @@ cJSON* discord_embed_to_cjson(discord_embed_t* embed)
     if(embed->url) cJSON_AddItemToObject(root, "url", cJSON_CreateStringReference(embed->url));
     cJSON_AddNumberToObject(root, "color", embed->color);
     if(embed->footer) cJSON_AddItemToObject(root, "footer", discord_embed_footer_to_cjson(embed->footer));
+    if(embed->image) cJSON_AddItemToObject(root, "image", discord_embed_image_to_cjson(embed->image));
+    if(embed->thumbnail) cJSON_AddItemToObject(root, "thumbnail", discord_embed_image_to_cjson(embed->thumbnail));
 
     return root;
 }

--- a/src/discord/private/_json.c
+++ b/src/discord/private/_json.c
@@ -338,6 +338,20 @@ static cJSON* discord_embed_author_to_cjson(discord_embed_author_t* author)
     return root;
 }
 
+static cJSON* discord_embed_field_to_cjson(discord_embed_field_t* field)
+{
+    if(!field)
+        return NULL;
+    
+    cJSON* root = cJSON_CreateObject();
+
+    if(field->name) cJSON_AddItemToObject(root, "name", cJSON_CreateStringReference(field->name));
+    if(field->value) cJSON_AddItemToObject(root, "value", cJSON_CreateStringReference(field->value));
+    cJSON_AddBoolToObject(root, "inline", field->is_inline);
+
+    return root;
+}
+
 cJSON* discord_embed_to_cjson(discord_embed_t* embed)
 {
     if(!embed)
@@ -353,6 +367,16 @@ cJSON* discord_embed_to_cjson(discord_embed_t* embed)
     if(embed->image) cJSON_AddItemToObject(root, "image", discord_embed_image_to_cjson(embed->image));
     if(embed->thumbnail) cJSON_AddItemToObject(root, "thumbnail", discord_embed_image_to_cjson(embed->thumbnail));
     if(embed->author) cJSON_AddItemToObject(root, "author", discord_embed_author_to_cjson(embed->author));
+
+    if(embed->_fields_len > 0) {
+        cJSON* fields = cJSON_CreateArray();
+
+        for(uint8_t i = 0; i < embed->_fields_len; i++) {
+            cJSON_AddItemToArray(fields, discord_embed_field_to_cjson(embed->fields[i]));
+        }
+
+        cJSON_AddItemToObject(root, "fields", fields);
+    }
 
     return root;
 }


### PR DESCRIPTION
This PR gives Bot ability to send embeds. Example will be added to [esp-discord-examples](https://github.com/abobija/esp-discord-examples) repo.

Supported members for embed struct:
- title
- description
- url
- color
- footer
  - text
  - icon_url
- thumbnail
  - url
- image
  - url
- author
  - name
  - url
  - icon_url
- fields []
  - name
  - value
  - inline